### PR TITLE
Fixed search feature

### DIFF
--- a/Assets/Scenes/Catalog.unity
+++ b/Assets/Scenes/Catalog.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657844, g: 0.49641222, b: 0.57481694, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -385,7 +385,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 1}
   m_AnchorMax: {x: 0.5, y: 1}
-  m_AnchoredPosition: {x: 0.000091552734, y: 0.0001762426}
+  m_AnchoredPosition: {x: -390.00003, y: 0.000117563184}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0, y: 1}
 --- !u!114 &201577807
@@ -1467,7 +1467,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 2081525147}
   m_HandleRect: {fileID: 2081525146}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:

--- a/Assets/scripts/LoadCatalog.cs
+++ b/Assets/scripts/LoadCatalog.cs
@@ -5,12 +5,9 @@ using UnityEngine;
 using UnityEngine.SceneManagement;
 using GoogleARCore;
 using System;
-//using UnityEngine.Experimental.UIElements;
 
 public class LoadCatalog : MonoBehaviour
-{
-    Resolution[] resolutions;
-    
+{    
     public GameObject categoryListingPrefab;
     public GameObject itemListingPrefab;
 
@@ -247,15 +244,13 @@ public class LoadCatalog : MonoBehaviour
     {
         GameObject content = GameObject.Find("Content");
 
-        foreach (GameObject catListing in categoryListings)
-        {
-            catListing.SetActive(false);
-        }
+        hideListings();
 
         foreach (Item itemInList in loadedItems)
         {
             if (itemInList.GetCategories().Contains(category))
             {
+                showListing(itemInList);
                 content.transform.Find($"Listing: {itemInList.GetItemID()} {itemInList.GetName()}").gameObject.SetActive(true);
             }
         }        


### PR DESCRIPTION
When selecting a category then searching the item in the category would stay active, even if it didn't match the search results.
This was because it wasn't added into the visible/disabled lists when a category was clicked via the UI.

This is now fixed.